### PR TITLE
Composer copy example environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Slackwolf requires PHP 5.5+ and [Composer](https://getcomposer.org/). It may not
 git clone http://github.com/chrisgillis/slackwolf
 cd slackwolf
 composer install
-cp .env.default .env
 ```
 
 Edit the `.env` file with a valid real-time messaging bot token from Slack. Get a valid token from the "Custom Integrations" tab of your Slack "Configure Apps" page. Also be sure to put the correct bot name in the `.env` file as well.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "post-root-package-install": [
-            "php -r \"copy('.env.example', '.env');\""
+            "php -r \"copy('.env.default', '.env');\""
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {"Slackwolf\\": "src/"}
+    },
+    "scripts": {
+        "post-root-package-install": [
+            "php -r \"copy('.env.example', '.env');\""
+        ]
     }
 }


### PR DESCRIPTION
use composer post install command to copy the .env file instead of requiring manual copying