### PR TITLE
updates devristo/phpws in composer.lock to fix PHP7 connection problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Slackwolf currently supports Seer, Bodyguard, Lycan, Tanner, Beholder, Villager,
 `/invite` the bot and type !help
 
 ## Installation
-Slackwolf requires PHP 5.5+ and [Composer](https://getcomposer.org/). It may not work with PHP7 due to one of its dependencies.
+Slackwolf requires PHP 5.5+ and [Composer](https://getcomposer.org/).
 
 ```
 git clone http://github.com/chrisgillis/slackwolf

--- a/composer.lock
+++ b/composer.lock
@@ -91,12 +91,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Devristo/phpws.git",
-                "reference": "5c495fa15555c8a4eb40c000e28ab6205d72e7f7"
+                "reference": "3166c21bdce4a84937ab9e42564a85acb6c2b5db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Devristo/phpws/zipball/5c495fa15555c8a4eb40c000e28ab6205d72e7f7",
-                "reference": "5c495fa15555c8a4eb40c000e28ab6205d72e7f7",
+                "url": "https://api.github.com/repos/Devristo/phpws/zipball/3166c21bdce4a84937ab9e42564a85acb6c2b5db",
+                "reference": "3166c21bdce4a84937ab9e42564a85acb6c2b5db",
                 "shasum": ""
             },
             "require": {
@@ -120,7 +120,7 @@
                 }
             ],
             "description": "WebSocket Server and Client library for PHP",
-            "time": "2015-07-10 14:59:37"
+            "time": "2016-02-08 15:53:28"
         },
         {
             "name": "evenement/evenement",


### PR DESCRIPTION
This app depends on coderstephen/slack-client which depends on Devristo/phpws.
The problem that PHP7 cannot make connection in slackwolf is caused by Devristo/phpws.
coderstephen/slack-client depends on Devristo/phpws dev-master,
which already contains the fix from https://github.com/Devristo/phpws/pull/76.

So we only need to update this package in the slackwolf app to get the latest fix.

Related issue on coderstephen/slack-client: https://github.com/coderstephen/slack-client/issues/14