### PR TITLE
check game is over after Hunter shoots

### DIFF
--- a/src/Game/GameManager.php
+++ b/src/Game/GameManager.php
@@ -147,12 +147,12 @@ class GameManager
 
             $this->onNightEnd($game);
 
-            if ($game->isOver()) {
-                $this->onGameOver($game);
+            if ($game->hunterNeedsToShoot) {
                 return;
             }
 
-            if ($game->hunterNeedsToShoot) {
+            if ($game->isOver()) {
+                $this->onGameOver($game);
                 return;
             }
         }


### PR DESCRIPTION
@chrisgillis hey sorry Chris, quick minor bug fix.  The order of the calls to check if a game is over and the Hunter needs to shoot had to be swapped.  

Yesterday we played a game where the Hunter was killed at night and was given a choice to shoot one of the two remaining people, but the GameManager ended the game anyways because it calculated the wolf had won with only 2 people left.

The Hunter should always get a choice to shoot before the game ends.  If he needs to the Hunter can do "!shoot noone" to end the game.

Thanks dude!