### PR TITLE
Check Liveness of Websocket

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .env
 .git
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+run.sh

--- a/README.md
+++ b/README.md
@@ -20,8 +20,34 @@ docker run -d --name slackwolf --restart always \
    gillisct/slackwolf
 ```
 
+## Development via Docker
+In order to use a docker container for development of this project, first build
+the container with the following command:
+```
+docker build -t {namespace}/slackwolf .
+```
+Substituting `namespace` for a relevant namespace you wish to refer the
+container in, commonly your dockerhub username. Then modify following command
+with your Slack Credentials and chosen namespace:  
+
+```
+docker run -it --name slackwolf \
+-e "BOT_TOKEN=" \
+-e "TIMEZONE=" \
+-e "BOT_NAME=" \
+-e "DEBUG=1" \
+{namespace}/slackwolf \
+-v "$(pwd)/src":/usr/src/slackwolf/src \
+/bin/bash
+```
+This will provide you wish a shell inside the container, while still having the
+changes made within the `src` directory reflected within the container
+environment.
+
+To start the bot within the container type `php bot.php`
+
 ## Source Installation
-If you don't want to use docker, you can install from source. 
+If you don't want to use docker, you can install from source.
 
 Slackwolf requires PHP 5.5+ and [Composer](https://getcomposer.org/).
 

--- a/run_example.sh
+++ b/run_example.sh
@@ -1,8 +1,0 @@
-docker run -it --name slackwolf \
--e "BOT_TOKEN=" \
--e "TIMEZONE=" \
--e "BOT_NAME=" \
--e "DEBUG=1" \
-owena11/slackwolf \
-#-v "$(pwd)/src":/usr/src/slackwolf/src \
-#/bin/bash

--- a/run_example.sh
+++ b/run_example.sh
@@ -1,0 +1,8 @@
+docker run -it --name slackwolf \
+-e "BOT_TOKEN=" \
+-e "TIMEZONE=" \
+-e "BOT_NAME=" \
+-e "DEBUG=1" \
+owena11/slackwolf \
+#-v "$(pwd)/src":/usr/src/slackwolf/src \
+#/bin/bash

--- a/src/SlackRTMClient.php
+++ b/src/SlackRTMClient.php
@@ -86,7 +86,6 @@ class SlackRTMClient extends RealTimeClient
                     ];
                     $this->pong_response = False;
                     $this->websocket->send(json_encode($data));
-                    echo "Ping sent...\r\n";
                 }
             });
 

--- a/src/SlackRTMClient.php
+++ b/src/SlackRTMClient.php
@@ -25,7 +25,6 @@ use Slackwolf\Message\Message;
  */
 class SlackRTMClient extends RealTimeClient
 {
-
     public function connect()
     {
         /*
@@ -90,9 +89,7 @@ class SlackRTMClient extends RealTimeClient
             });
 
         });
-
         return $deferred;
-
     }
     /**
      * @param $channelId
@@ -107,5 +104,4 @@ class SlackRTMClient extends RealTimeClient
             $this->channels[$channel->getId()] = $channel;
         });
     }
-
 }

--- a/src/SlackRTMClient.php
+++ b/src/SlackRTMClient.php
@@ -50,10 +50,19 @@ class SlackRTMClient extends RealTimeClient
                  * result.
                  */
                 if(property_exists($this, 'pong_response')){
-                    if($this->pong_response){
-                        echo "Pong Acknowledged...\r\n";
-                    } else{
-                        echo "Pong Missing...\r\n";
+                    if (!$this->pong_response){
+                        echo "Pong Not Recived...\r\n";
+                        echo "Attempting to reconnet...\r\n";
+                        /*
+                         * Recall the connect function on the slack API
+                         */
+                        $this->connect()->then(function() {
+                            echo "Reconnected.\n";
+                        }, function(ConnectionException $e) {
+                            echo $e->getMessage();
+                            exit();
+                        });
+
                     }
                 }
                 /*

--- a/src/SlackRTMClient.php
+++ b/src/SlackRTMClient.php
@@ -12,6 +12,12 @@ use Slack\Channel;
 use Slack\Payload;
 use Slack\RealTimeClient;
 
+use GuzzleHttp;
+use React\EventLoop\LoopInterface;
+use React\Promise\Deferred;
+
+use Slackwolf\Message\Message;
+
 /**
  * Class SlackRTMClient
  *
@@ -19,44 +25,53 @@ use Slack\RealTimeClient;
  */
 class SlackRTMClient extends RealTimeClient
 {
-    public function __construct(LoopInterface $loop, GuzzleHttp\ClientInterface $httpClient = null)
+
+    public function connect()
     {
         /*
-         * Call the parent constructor
+         * Call the parent method
          */
-        parent::__construct($loop, $httpClient);
+        $deferred = parent::connect();
 
-        $this->loop->addPeriodicTimer(5, function () {
-            /*
-             * Check if a liveness test has been called before and look the the
-             * result.
-             */
-            if(property_exists($this, 'pong_response')){
-                if($this->pong_response){
-                    echo "Pong Acknowledged...\r\n";
-                } else{
-                    echo "Pong Missing...\r\n";
+        /* Queue our addition of the time onto the promise once its done.
+         */
+        $deferred->then(function() {
+                /*
+                 * If a pong response is returned down the pipes set the flag to true.
+                 */
+                echo "Pong Capture setup...\r\n";
+                $this->on('pong', function ($data) {
+                    $this->pong_response = True;
+                });
+        })->then(function () {
+            $this->loop->addPeriodicTimer(5, function () {
+                /*
+                 * Check if a liveness test has been called before and look the the
+                 * result.
+                 */
+                if(property_exists($this, 'pong_response')){
+                    if($this->pong_response){
+                        echo "Pong Acknowledged...\r\n";
+                    } else{
+                        echo "Pong Missing...\r\n";
+                    }
                 }
-            }
-            /*
-             * Send the ping request down the web socket in order to check the
-             * liveness.
-             */
-            $data = [
-                'id' => ++$this->lastMessageId,
-                'type' => 'ping',
-            ];
-            $this->pong_response = False;
-            $this->websocket->send(json_encode($data));
+                /*
+                 * Send the ping request down the web socket in order to check the
+                 * liveness.
+                 */
+                $data = [
+                    'id' => ++$this->lastMessageId,
+                    'type' => 'ping',
+                ];
+                $this->pong_response = False;
+                $this->websocket->send(json_encode($data));
+                echo "Ping sent...\r\n";
+            });
+
         });
 
-        /*
-         * If a pong response is returned down the pipes set the flag to true.
-         */
-        $this->websocket->on('pong', function ($message) {
-            $this->pong_response = True;
-        });
-
+        return $deferred;
 
     }
     /**


### PR DESCRIPTION
We've experienced the bot going offline randomly without producing any output, or throwing any exceptions. My best guess as to why this is happening is Slack closing the websocket used for communication on their end after it has been idle for a given period of time.

However since implementing the test for liveness of the websocket I have been unable to reproduce the bug, as there is a constant small amount of activity over the websocket event when the bot is idle.

This pull request implements the following : 

- Checks for disconnections of the websocket using ping/pong queries as suggested in the [Slack documentation](https://api.slack.com/rtm) every 5s.
- Requests a new connection if the websocket is found to be dead.
- Provides brief instructions on how to run the container for development.
- Added `vendor/` to `.dockerignore` to ensure a clean build of the container.

Some of this functionality seems suited to the underlying libraries, but as they are no longer actively maintained I've put the functionality in the existing subclass `SlackRTMClient`. My PhP isn't exactly my first language  so any comments on how this would more conventionally done would be greatly appreciated! 